### PR TITLE
pyre-extensions 0.0.32

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,18 @@ source:
   sha256: 5396715f14ea56c4d5fd0a88c57ca7e44faa468f905909edd7de4ad90ed85e55
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 0
+  skip: true  # [py<310]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - pip
     - setuptools
+    - wheel
   run:
-    - python >={{ python_min }}
+    - python
     - typing_inspect
     - typing-extensions
 
@@ -31,14 +32,24 @@ test:
     - pip check
   requires:
     - pip
-    - python {{ python_min }}
 
 about:
   home: https://pyre-check.org
-  summary: Type system extensions for use with the pyre type checker
+  summary: Type system extensions for use with the Pyre type checker
+  description: |
+    Pyre Extensions is a module that enhances Python's standard typing system with
+    features supported by the Pyre typechecker. It provides utilities including
+    none_throws for explicit Optional handling, ParameterSpecification for typing
+    decorators that preserve callable signatures, and a type-safe way to parse
+    JSON through the safe_json module, which validates JSON input against expected
+    type specifications rather than returning untyped data.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  doc_url: https://pyre-check.org/
+  dev_url: https://github.com/facebook/pyre-check/tree/main/pyre_extensions
 
 extra:
   recipe-maintainers:
     - jan-janssen
+    - bkreider

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ test:
     - pyre_extensions
   commands:
     - pip check
+    - python -m unittest pyre_extensions.tests.basic_test pyre_extensions.tests.safe_json_test
   requires:
     - pip
 
@@ -46,7 +47,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  doc_url: https://pyre-check.org/
+  doc_url: https://pyre-check.org
   dev_url: https://github.com/facebook/pyre-check/tree/main/pyre_extensions
 
 extra:


### PR DESCRIPTION
pyre-extensions 0.0.32

**Destination channel:** defaults

### Links

- [PKG-11457](https://anaconda.atlassian.net/browse/PKG-11457)
- Upstream repository: https://github.com/facebook/pyre-check/tree/main/pyre_extensions
- Upstream release: https://pypi.org/project/pyre-extensions/0.0.32/
- Relevant dependency PRs:

### Explanation of changes:

Adapts the existing conda-forge `noarch: python` recipe for the AnacondaRecipes defaults channel. pyre-extensions is a small pure-Python package that provides type system extensions used by the Pyre typechecker; it's listed as a runtime dependency of `xformers`, which is in turn a CUDA runtime dependency of `vllm 0.9.2`.

[PKG-11457]: https://anaconda.atlassian.net/browse/PKG-11457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ